### PR TITLE
Rename option `print_code` into `print-code` for common style

### DIFF
--- a/sold/src/lib.rs
+++ b/sold/src/lib.rs
@@ -408,6 +408,6 @@ pub struct Args {
     #[clap(long, value_parser)]
     pub silent: bool,
     /// After ASM compilation do not generate TVC but print the code cell only
-    #[clap(long("print_code"), value_parser)]
+    #[clap(long, value_parser)]
     pub print_code: bool,
 }

--- a/sold/tests/tests.rs
+++ b/sold/tests/tests.rs
@@ -39,7 +39,7 @@ fn test_trivial() -> Status {
         .arg("tests/Trivial.sol")
         .arg("--output-dir")
         .arg("tests")
-        .arg("--print_code")
+        .arg("--print-code")
         .assert()
         .success()
         .stdout(predicate::str::contains("code\":\"te6ccgECDAEAA"));


### PR DESCRIPTION
https://github.com/EverscaleGuild/ever-solidity/pull/2